### PR TITLE
バグ修正

### DIFF
--- a/app/Http/Controllers/PublicController.php
+++ b/app/Http/Controllers/PublicController.php
@@ -98,12 +98,7 @@ class PublicController extends Controller
                 $headKey = 4;
             }
             $headKeyCnt[$headKey]++;
-            if(!empty($attr)) {
-                $attrs = explode('class="', $attr);
-                $attrClass = str_replace('"', '', $attrs[1]) . ' lv-' . $headKey;
-            } else {
-                $attrClass = 'lv-' . $headKey;
-            }
+            $attrClass = 'lv-' . $headKey;
 
             $contents = str_replace($headTag, '<h' . $headKey . $attr . ' id="ttl-' . $headKey . '-' . $headKeyCnt[$headKey] . '">' . $str . '</h' . $headKey . '>', $contents);
             $tableOfContents[] = '<li class="' . $attrClass .'"><a href="#ttl-' . $headKey . '-' . $headKeyCnt[$headKey] . '">' . $str . '</a></li>';
@@ -111,7 +106,12 @@ class PublicController extends Controller
         if(!empty($tableOfContents)) {
             // 目次が存在する場合、「初めのh2タグの上」に目次を追加する
             $firstH2Tag = explode('<h2',$contents);
-            $contents = $firstH2Tag[0] . '<div class="table-of-contents"><h2>目次</h2><ul>' . implode('', $tableOfContents) . '</ul></div><h2' . $firstH2Tag[1];
+            $contents = $firstH2Tag[0] . '<div class="table-of-contents"><h2>目次</h2><ul>' . implode('', $tableOfContents) . '</ul></div>';
+            $i = 1;
+            while(isset($firstH2Tag[$i])) {
+                $contents .= '<h2' . $firstH2Tag[$i];
+                $i++;
+            }
         }
         $article->contents = $contents;
 

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -26,7 +26,7 @@
     </head>
     <body>
     <div class="header">
-        <div class="cms-name"><h1><a href="{{ url('/') }}"><img src="{{ asset('/images/umeko-logo.png') }}" alt="梅子"></a></h1></div>
+        <div class="cms-name"><a href="{{ url('/') }}"><img src="{{ asset('/images/umeko-logo.png') }}" alt="梅子"></a></div>
         <div class="header-right">
             <div>オープンソースのブログCMS「梅子」
                 <a href="https://github.com/naho-osada/umeko_cms" target="_blank" rel="noopener"><img src="{{ asset('/images/icons/GitHub-Mark-32px.png') }}" alt="GitHub"></a>

--- a/resources/views/public/article.blade.php
+++ b/resources/views/public/article.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="contents">
     <div class="article-area">
-        <h2 class="article_title"><a href="{{ $article->url }}" title="{{ $article->title }}" class="link_style_none">{{ $article->title }}</a></h2>
+        <h1 class="article_title"><a href="{{ $article->url }}" title="{{ $article->title }}" class="link_style_none">{{ $article->title }}</a></h1>
         <div class="article_post">{{ date('Y/n/j H:i', strtotime($article->publish_at)) }}@if($article->publish_at != $article->updated_at)（更新日&nbsp;{{ date('Y/n/j H:i', strtotime($article->updated_at)) }}）@endif</div>
         @if(!empty($article->icatch_thumbnail))
         <div class="article_icatch"><a href="{{ $article->url }}" title="{{ $article->title }}" class="link_style_none"><img src="@if($article->icatch_thumbnail) {{ $article->icatch_thumbnail }} @endif" id="icatch-thumbnail"></a></div>


### PR DESCRIPTION
目次機能の修正 ページタイトルをh1タグに、サイトタイトルからh1タグを外す / 属性付与の余分なところを省いた / 2つ目のh2タグが表示されなくなるバグの修正 #1