### PR TITLE
公開日が投稿日と比べて同日の時間違い、または同日よりも前の場合は更新日を表示しない

### DIFF
--- a/resources/views/public/article.blade.php
+++ b/resources/views/public/article.blade.php
@@ -4,7 +4,7 @@
 <div class="contents">
     <div class="article-area">
         <h1 class="article_title"><a href="{{ $article->url }}" title="{{ $article->title }}" class="link_style_none">{{ $article->title }}</a></h1>
-        <div class="article_post">{{ date('Y/n/j H:i', strtotime($article->publish_at)) }}@if($article->publish_at != $article->updated_at)（更新日&nbsp;{{ date('Y/n/j H:i', strtotime($article->updated_at)) }}）@endif</div>
+        <div class="article_post">{{ date('Y/n/j H:i', strtotime($article->publish_at)) }}@if($article->publish_at != $article->updated_at && date('Ymd', strtotime($article->publish_at)) < date('Ymd', strtotime($article->updated_at)))（更新日&nbsp;{{ date('Y/n/j H:i', strtotime($article->updated_at)) }}）@endif</div>
         @if(!empty($article->icatch_thumbnail))
         <div class="article_icatch"><a href="{{ $article->url }}" title="{{ $article->title }}" class="link_style_none"><img src="@if($article->icatch_thumbnail) {{ $article->icatch_thumbnail }} @endif" id="icatch-thumbnail"></a></div>
         @endif


### PR DESCRIPTION
公開日が2022/4/8 13:00で
更新日が2022/4/8 14:00の場合
または
更新日が2022/4/7などの4/8 13:00よりも前
の場合、更新日を表示しない修正